### PR TITLE
Fix the order of the setup procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,21 @@ python scripts/data_collector/yahoo/collector.py normalize_data --source_dir ~/.
 python scripts/dump_bin.py dump_all --csv_path ~/.qlib/stock_data/source/cn_1d_nor --qlib_dir ~/.qlib/qlib_data/cn_data --freq day --exclude_fields date,symbol
 ```
 
-After that, clone this repository and do some setup work.
+After that, clone this repository and install the dependencies.
 ```bash
 cd <your_workspace_dir>
 git clone https://github.com/jingedawang/StockPredictor.git && cd StockPredictor
 pip install -r stock_predictor/requirements.txt
-python stock_predictor/setup.py
 ```
 
-Then, we need to train a prediction model.
+Train a prediction model.
 ```bash
 python stock_predictor/train_two_week_predictor.py
+```
+
+Do some setup work for the prediction service. This includes loading the stock list into database and doing a complete prediction for all the stocks.
+```bash
+python stock_predictor/setup.py
 ```
 
 Before starting the service, we need to setup a schedule to automatically update the data everyday after the market closing time.

--- a/config/update_data.crontab
+++ b/config/update_data.crontab
@@ -1,4 +1,4 @@
 # Update stock data at 16:00 in each working day afternoon, one hour past the China stock market closing.
 0 16 * * 1-5 tmux send-keys -t update-data 'python ~/projects/qlib/scripts/data_collector/yahoo/collector.py update_data_to_bin --qlib_data_1d_dir ~/.qlib/qlib_data/cn_data' Enter
 # Predict for all the stocks based on today's new data.
-0 20 * * 1-5 tmux send-keys -t update-data 'python ~/projects/StockPredictor/stock_predictor/predict_all.py' Enter
+0 20 * * 1-5 tmux send-keys -t update-data 'cd ~/projects/StockPredictor && python ~/projects/StockPredictor/stock_predictor/predict_all.py' Enter


### PR DESCRIPTION
The setup.py includes a predict_all invokation, which must be executed after the model was generated.

So, we swap the execution order of the setup.py and train_two_week_predictor.py.

Since the model was generated under the project folder. We need to `cd` to the project folder in the crontab when doing the daily prediction.